### PR TITLE
fix: thumbnail loading crash on android

### DIFF
--- a/convention/publishing/src/main/kotlin/com/attafitamim/file/picker/publish/PublishConventions.kt
+++ b/convention/publishing/src/main/kotlin/com/attafitamim/file/picker/publish/PublishConventions.kt
@@ -10,7 +10,7 @@ import org.gradle.api.publish.maven.MavenPomScm
 
 class PublishConventions : Plugin<Project> {
 
-    private val version = "0.1.0-alpha08"
+    private val version = "0.1.0-alpha09"
     private val group = "com.attafitamim.file.picker"
 
     override fun apply(project: Project) {

--- a/layout/src/androidMain/kotlin/com/attafitamim/file/picker/ui/utils/ImageUtils.android.kt
+++ b/layout/src/androidMain/kotlin/com/attafitamim/file/picker/ui/utils/ImageUtils.android.kt
@@ -24,6 +24,18 @@ fun String.pathToImageBitmap(context: Context, quality: Double = IMAGE_MAX_QUALI
         BitmapFactory.decodeStream(inputStream)?.compress(quality)?.asImageBitmap()
     }
 
+fun Bitmap.compress(
+    width: Int,
+    height: Int,
+    quality: Double
+): Bitmap {
+    if (this.width <= width && this.height <= height) {
+        return this
+    }
+
+    return compress(quality)
+}
+
 fun Bitmap.compress(quality: Double): Bitmap {
     if (quality == IMAGE_MAX_QUALITY) {
         return this


### PR DESCRIPTION
Some files no longer exist but are still in the Media store database, these files with throw en exception if we try to create thumbnails for them. The rorr looks like this
```kotlin
java.io.FileNotFoundException: Failed to create image decoder with message 'unimplemented'Input contained an error.                      	
at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:151)                                                                        	
at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:814)
...
```